### PR TITLE
Add option to save files by default instead of printing to stdout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ make install bindir=/path/to/bin
 $ transfer --help
 Usage:
   transfer download [<url> [file]]
-    [--decrypt|-d] [--file|-f <file>] [--password|-p <password>] [--trace|-x]
+    [--decrypt|-d] [--save|--cat] [--file|-f <file>] [--password|-p <password>] [--trace|-x]
     [--url|-u <url>]
 
   transfer upload [<file> [slug]]
@@ -107,6 +107,10 @@ More Information:
   chat    https://rockymadden-slack.herokuapp.com
   repo    https://github.com/rockymadden/transfer-cli
 ```
+
+### Configurable options
+Change these variables at the top of the script to change the default behaviour.
+  * `use_stdout`: set to `no` to save downloaded files by default instead of writing them to standard output (may be less pipe-friendly). This option can be overridden through the `--cat` or `--save` CLI arguments.
 
 ## License
 ```

--- a/src/transfer
+++ b/src/transfer
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# CONFIGURABLE OPTIONS #################################################################################
+use_stdout="yes"
+
 # COMMAND PARSING #################################################################################
 cmd="${1}" ; shift
 
@@ -11,12 +14,14 @@ esac
 # ARGUMENT AND OPTION PARSING #####################################################################
 while (( "$#" )); do
   case "${1}" in
+    --cat) use_stdout="yes" ; shift ;;
     --decrypt|-d) decrypt=0 ; shift ;;
     --encrypt|-e) encrypt=0 ; shift ;;
     --file=*) file=${1/--file=/''} ; shift ;;
     --file*|-f*) file=${2} ; shift ; shift ;;
     --password=*) password=${1/--password=/''} ; shift ;;
     --password*|-p*) password=${2} ; shift ; shift ;;
+    --save) use_stdout="no" ; shift ;;
     --slug=*) slug=${1/--slug=/''} ; shift ;;
     --slug*|-s*) slug=${2} ; shift ; shift ;;
     --trace|-x) trace='set -x' ; shift ;;
@@ -53,6 +58,8 @@ esac
 
 # COMMAND FUNCTIONS ###############################################################################
 function download() {
+  [ -z "${file}" -a "${use_stdout}" == "no" ] && file=${url##*/}
+
   if [ -n "${file}" ]; then
     local path=$(greadlink -f "${file}" 2> /dev/null || readlink -f "${file}" 2> /dev/null)
 
@@ -77,7 +84,7 @@ function help() {
   echo '    [--url|-u <url>]'
   echo
   echo "  ${bin} upload [<file> [slug]]"
-  echo '    [--encrypt|-e] [--file|-f <file>] [--password|-p <password>] [--slug|-s <slug>]'
+  echo '    [--encrypt|-e] [--max-days|-y <days>] [--max-downloads|-l <dls>] [--file|-f <file>] [--password|-p <password>] [--slug|-s <slug>]'
   echo '    [--trace|-x]'
   echo
   echo 'Commands:'
@@ -122,7 +129,7 @@ function upload() {
       curl --progress-bar --upload-file - "https://transfer.sh/${slug}" > ${tmpurl}
   fi
 
-  cat ${tmpurl}
+  cat ${tmpurl} && [ "${use_stdout}" == "no" ] && echo
   if type pbcopy &> /dev/null; then cat ${tmpurl} | tr -d '\n' | pbcopy; fi
 }
 


### PR DESCRIPTION
Hello again,

As I mentioned in #6, I have made another change to the script, motivated by the fact that I expect the default behaviour to save the downloaded file instead of printing it to stdout. So, I've added a configuration option at the top of the script to do just that. However, I understand that one of your initial goals when making this was to be pipe-friendly, and this change may affect that, so I've put it in a separate pull request.

Note that I haven't changed the default way the script works, but setting `use_stdout=no` will cause it to save downloaded file by default, as well as print the upload URL on a separate line.